### PR TITLE
Adjusted the scopeFixedOrder method in the Entry model to use FIELD()…

### DIFF
--- a/src/Model/Entry.php
+++ b/src/Model/Entry.php
@@ -1007,7 +1007,9 @@ class Entry extends AbstractEntity
 
         call_user_func_array([$this, 'scopeEntryId'], func_get_args());
 
-        return $query->orderBy('FIELD('.implode(', ', $fixedOrder).')', 'asc');
+        $tablePrefix = $query->getQuery()->getConnection()->getTablePrefix();
+
+        return $query->orderByRaw('FIELD('.$tablePrefix.'channel_titles.entry_id,'.implode(', ', $fixedOrder).')');
     }
 
     /**


### PR DESCRIPTION
Fixes #25. 

Replaces `$query->orderBy` with `$query->orderByRaw`, uses `channel_titles.entry_id` as FIELD() comparison column, uses correct table prefix lookup.