### PR TITLE
Fix to prevent double hydration

### DIFF
--- a/src/Collection/AbstractTitleCollection.php
+++ b/src/Collection/AbstractTitleCollection.php
@@ -149,6 +149,18 @@ abstract class AbstractTitleCollection extends AbstractModelCollection implement
     }
 
     /**
+     * Determine if all items in the collection are fully hydrated
+     *
+     * @return bool
+     */
+    public function isHydrated()
+    {
+        return $this->reduce(function ($carry, $item) {
+            return $carry && $item->hydrated;
+        }, true);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function toJson($options = 0)

--- a/src/Hydrator/AbstractHydrator.php
+++ b/src/Hydrator/AbstractHydrator.php
@@ -73,5 +73,7 @@ abstract class AbstractHydrator implements HydratorInterface
     /**
      * {@inheritdoc}
      */
-    abstract public function hydrate(AbstractEntity $entity, AbstractProperty $property);
+    public function hydrate(AbstractEntity $entity, AbstractProperty $property) {
+        $entity->hydrated = true;
+    }
 }

--- a/src/Hydrator/AssetsHydrator.php
+++ b/src/Hydrator/AssetsHydrator.php
@@ -98,6 +98,8 @@ class AssetsHydrator extends AbstractHydrator
      */
     public function hydrate(AbstractEntity $entity, AbstractProperty $property)
     {
+        parent::hydrate($entity, $property);
+
         if (isset($this->selections[$entity->getType()][$entity->getId()][$property->getId()])) {
             $value = $this->selections[$entity->getType()][$entity->getId()][$property->getId()];
         } else {

--- a/src/Hydrator/DateHydrator.php
+++ b/src/Hydrator/DateHydrator.php
@@ -23,6 +23,8 @@ class DateHydrator extends AbstractHydrator
      */
     public function hydrate(AbstractEntity $entity, AbstractProperty $property)
     {
+        parent::hydrate($entity, $property);
+
         $value = $entity->getAttribute($property->getIdentifier());
 
         $value = $value ? Carbon::createFromFormat('U', $value) : null;

--- a/src/Hydrator/ExplodeHydrator.php
+++ b/src/Hydrator/ExplodeHydrator.php
@@ -22,6 +22,8 @@ class ExplodeHydrator extends AbstractHydrator
      */
     public function hydrate(AbstractEntity $entity, AbstractProperty $property)
     {
+        parent::hydrate($entity, $property);
+
         $value = $entity->getAttribute($property->getIdentifier());
 
         $value = $value ? explode("\n", $value) : null;

--- a/src/Hydrator/FileHydrator.php
+++ b/src/Hydrator/FileHydrator.php
@@ -97,6 +97,8 @@ class FileHydrator extends AbstractHydrator
      */
     public function hydrate(AbstractEntity $entity, AbstractProperty $property)
     {
+        parent::hydrate($entity, $property);
+
         $value = $entity->getAttribute($property->getIdentifier());
 
         $value = $value && isset($this->files[$value]) ? $this->files[$value] : null;

--- a/src/Hydrator/GridHydrator.php
+++ b/src/Hydrator/GridHydrator.php
@@ -123,6 +123,8 @@ class GridHydrator extends AbstractHydrator
      */
     public function hydrate(AbstractEntity $entity, AbstractProperty $property)
     {
+        parent::hydrate($entity, $property);
+
         $value = isset($this->sortedRows[$entity->getId()][$property->getId()]) ? $this->sortedRows[$entity->getId()][$property->getId()] : new GridRowCollection();
 
         $entity->setAttribute($property->getName(), $value);

--- a/src/Hydrator/MatrixHydrator.php
+++ b/src/Hydrator/MatrixHydrator.php
@@ -115,6 +115,8 @@ class MatrixHydrator extends AbstractHydrator
      */
     public function hydrate(AbstractEntity $entity, AbstractProperty $property)
     {
+        parent::hydrate($entity, $property);
+
         $value = isset($this->sortedRows[$entity->getId()][$property->getId()]) ? $this->sortedRows[$entity->getId()][$property->getId()] : new MatrixRowCollection();
 
         $entity->setAttribute($property->getName(), $value);

--- a/src/Hydrator/ParentsHydrator.php
+++ b/src/Hydrator/ParentsHydrator.php
@@ -61,6 +61,8 @@ class ParentsHydrator extends AbstractHydrator
      */
     public function hydrate(AbstractEntity $entity, AbstractProperty $property)
     {
+        parent::hydrate($entity, $property);
+
         $entries = isset($this->entries[$entity->getId()]) ? $this->entries[$entity->getId()] : array();
 
         $value = $this->relationshipCollection->createChildCollection($entries);

--- a/src/Hydrator/PipeHydrator.php
+++ b/src/Hydrator/PipeHydrator.php
@@ -22,6 +22,8 @@ class PipeHydrator extends AbstractHydrator
      */
     public function hydrate(AbstractEntity $entity, AbstractProperty $property)
     {
+        parent::hydrate($entity, $property);
+
         $value = $entity->getAttribute($property->getIdentifier());
 
         $value = $value ? explode("|", $value) : null;

--- a/src/Hydrator/PlayaHydrator.php
+++ b/src/Hydrator/PlayaHydrator.php
@@ -78,6 +78,8 @@ class PlayaHydrator extends AbstractHydrator
      */
     public function hydrate(AbstractEntity $entity, AbstractProperty $property)
     {
+        parent::hydrate($entity, $property);
+
         $entries = isset($this->entries[$entity->getType()][$entity->getId()][$property->getId()])
             ? $this->entries[$entity->getType()][$entity->getId()][$property->getId()] : array();
 

--- a/src/Hydrator/RelationshipHydrator.php
+++ b/src/Hydrator/RelationshipHydrator.php
@@ -65,6 +65,8 @@ class RelationshipHydrator extends AbstractHydrator
      */
     public function hydrate(AbstractEntity $entity, AbstractProperty $property)
     {
+        parent::hydrate($entity, $property);
+
         $entries = isset($this->entries[$entity->getType()][$entity->getId()][$property->getId()])
             ? $this->entries[$entity->getType()][$entity->getId()][$property->getId()] : array();
 

--- a/src/Hydrator/SiblingsHydrator.php
+++ b/src/Hydrator/SiblingsHydrator.php
@@ -61,6 +61,8 @@ class SiblingsHydrator extends AbstractHydrator
      */
     public function hydrate(AbstractEntity $entity, AbstractProperty $property)
     {
+        parent::hydrate($entity, $property);
+
         $value = isset($this->entries[$entity->getId()]) ? $this->entries[$entity->getId()] : array();
 
         $value = $this->relationshipCollection->createChildCollection($entries);

--- a/src/Hydrator/WysiwygHydrator.php
+++ b/src/Hydrator/WysiwygHydrator.php
@@ -59,6 +59,8 @@ class WysiwygHydrator extends AbstractHydrator
      */
     public function hydrate(AbstractEntity $entity, AbstractProperty $property)
     {
+        parent::hydrate($entity, $property);
+
         $value = $this->parse($entity->getAttribute($property->getIdentifier()));
 
         $entity->setAttribute($property->getName(), $value);

--- a/src/Model/AbstractEntity.php
+++ b/src/Model/AbstractEntity.php
@@ -14,6 +14,13 @@ namespace rsanchez\Deep\Model;
  */
 abstract class AbstractEntity extends Model
 {
+
+    /**
+     * Entity hydration state
+     * @var bool
+     */
+    protected $hydrated = false;
+
     /**
      * Get the entity ID (eg. entry_id or row_id)
      * @return string|int

--- a/src/Model/Entry.php
+++ b/src/Model/Entry.php
@@ -67,7 +67,7 @@ class Entry extends Title
 
         $collection = call_user_func($method, $models, self::$channelRepository, self::$fieldRepository);
 
-        if ($models) {
+        if ($models && !$collection->isHydrated()) {
             $this->hydrateCollection($collection);
         }
 

--- a/src/Model/Title.php
+++ b/src/Model/Title.php
@@ -267,7 +267,7 @@ class Title extends AbstractEntity
 
     /**
      * Loop through all the hydrators to set Entry custom field attributes
-     * @param  \rsanchez\Deep\Collection\TitleCollection $collection
+     * @param  \rsanchez\Deep\Collection\AbstractTitleCollection $collection
      * @return void
      */
     public function hydrateCollection(AbstractTitleCollection $collection)


### PR DESCRIPTION
Hey @rsanchez, while using Deep we started to see pulling models for complex entries take a fairly significant amount of time to populate (on the order of 50 secs). I dove into the specifics of the addon and discovered that due, in part, to Eloquent that models are hydrating twice. See query log:

```
select * from `exp_channels`;
select * from `exp_channel_titles` inner join `exp_channel_data` on `exp_channel_titles`.`entry_id` = `exp_channel_data`.`entry_id` left join `exp_fm_search_channels` on `exp_channel_titles`.`channel_id` = `exp_fm_search_channels`.`channel_id` where `exp_channel_titles`.`entry_id` in ( "68362" ) and (select count(*) from `exp_categories` inner join `exp_category_posts` on `exp_category_posts`.`cat_id` = `exp_categories`.`cat_id` where `exp_channel_titles`.`entry_id` = `exp_category_posts`.`entry_id` and `exp_categories`.`cat_id` in (586, 60)) = 0;
select * from `exp_channel_fields` order by field_type IN ('matrix', 'grid') DESC, field_type IN ('playa', 'relationship') DESC, `field_order` asc;
select * from `exp_grid_columns` where `field_id` in ( "439" , "531" ) order by `col_order` asc;
select * from `exp_channel_titles` inner join `exp_channel_data` on `exp_channel_titles`.`entry_id` = `exp_channel_data`.`entry_id` inner join `exp_relationships` on `exp_relationships`.`child_id` = `exp_channel_titles`.`entry_id` where `exp_relationships`.`parent_id` in (68362) order by `order` asc;
select * from `exp_channel_grid_field_439` where `entry_id` in (68362) order by `row_order` asc;
select * from `exp_channel_grid_field_531` where `entry_id` in (68362) order by `row_order` asc;
select * from `exp_files`;
select * from `exp_upload_prefs`;
select * from `exp_grid_columns` where `field_id` in ( "439" , "531" ) order by `col_order` asc;
select * from `exp_channel_titles` inner join `exp_channel_data` on `exp_channel_titles`.`entry_id` = `exp_channel_data`.`entry_id` inner join `exp_relationships` on `exp_relationships`.`child_id` = `exp_channel_titles`.`entry_id` where `exp_relationships`.`parent_id` in (68362) order by `order` asc;
select * from `exp_channel_grid_field_439` where `entry_id` in (68362) order by `row_order` asc;
select * from `exp_channel_grid_field_531` where `entry_id` in (68362) order by `row_order` asc;
select * from `exp_files`;
```

You'll see that there are 4 queries that repeat and this is due to the call to `$builder->getModels($columns)` and then later to `$builder->getModel()->newCollection($models)` in `Builder.php::get()`. Both of these end up calling for a `newCollection()` on the model which on the Entry model results in multiple calls to `$this->hydrateCollection($collection)`.

To fix this issue, I added a state check to the Collections which indicates if they have been hydrated. What this does is allows the call to `$builder->getModels($columns)` to do the initial hydration it needs to do, but skips it on the second pass while calling `$builder->getModel()->newCollection($models)`. The `isHydrated()` method is not cached which would allow for any non-hydrated additions to the collection to classify the entire collection as unhydrated and would force another set up queries and population of the models.

Let me know if there is anything further I can do here, but we saw it make a 50% speed improvement in our application. Thanks!